### PR TITLE
Fix bug

### DIFF
--- a/xlens/simulation/loader.py
+++ b/xlens/simulation/loader.py
@@ -194,7 +194,6 @@ class MakeDMExposure(SimulateBase):
             pixel_scale=scale,
             buff=self.buff,
             layout=self.layout,
-            density=0,
         )
         psf_obj = make_fixed_psf(
             psf_type="moffat",


### PR DESCRIPTION
`WLDeblendGalaxyCatalog` doesn't accept density argument